### PR TITLE
local_address() preserves INADDR_ANY

### DIFF
--- a/include/simulator/simulator.hpp
+++ b/include/simulator/simulator.hpp
@@ -191,6 +191,44 @@ namespace sim
 			return ec;
 		}
 
+		typename Protocol::endpoint local_endpoint(boost::system::error_code& ec) const
+		{
+			if (!m_open)
+			{
+				ec = error::bad_descriptor;
+				return typename Protocol::endpoint{};
+			}
+
+			return m_user_bound_to;
+		}
+
+		typename Protocol::endpoint local_endpoint() const
+		{
+			boost::system::error_code ec;
+			auto const ret = local_endpoint(ec);
+			if (ec) throw boost::system::system_error(ec);
+			return ret;
+		}
+
+		typename Protocol::endpoint local_bound_to(boost::system::error_code& ec) const
+		{
+			if (!m_open)
+			{
+				ec = error::bad_descriptor;
+				return typename Protocol::endpoint{};
+			}
+
+			return m_bound_to;
+		}
+
+		typename Protocol::endpoint local_bound_to() const
+		{
+			boost::system::error_code ec;
+			auto const ret = local_bound_to(ec);
+			if (ec) throw boost::system::system_error(ec);
+			return ret;
+		}
+
 		template <class Option>
 		boost::system::error_code get_option(Option&
 			, boost::system::error_code& ec) { return ec; }
@@ -235,6 +273,12 @@ namespace sim
 		io_service& m_io_service;
 
 		typename Protocol::endpoint m_bound_to;
+
+		// this is the interface the user requested to bind to (in order to
+		// distinguish the concrete interface it was bound to and INADDR_ANY if
+		// that was requested). We keep this separately to return it as the local
+		// endpoint
+		typename Protocol::endpoint m_user_bound_to;
 
 		// this is an object implementing the sink interface, forwarding
 		// packets to this socket. If this socket is destructed, this forwarder
@@ -417,9 +461,6 @@ namespace sim
 			socket(socket&&);
 
 			lowest_layer_type& lowest_layer() { return *this; }
-
-			udp::endpoint local_endpoint(boost::system::error_code& ec) const;
-			udp::endpoint local_endpoint() const;
 
 			boost::system::error_code bind(ip::udp::endpoint const& ep
 				, boost::system::error_code& ec);
@@ -709,8 +750,6 @@ namespace sim
 			boost::system::error_code bind(ip::tcp::endpoint const& ep
 				, boost::system::error_code& ec);
 			void bind(ip::tcp::endpoint const& ep);
-			tcp::endpoint local_endpoint(boost::system::error_code& ec) const;
-			tcp::endpoint local_endpoint() const;
 			tcp::endpoint remote_endpoint(boost::system::error_code& ec) const;
 			tcp::endpoint remote_endpoint() const;
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -236,15 +236,15 @@ namespace sim
 		// create a channel
 		std::shared_ptr<aux::channel> c = std::make_shared<aux::channel>();
 
-		asio::ip::tcp::endpoint from = s->local_endpoint(ec);
+		asio::ip::tcp::endpoint from = s->local_bound_to(ec);
 
 		route network_route = m_config.channel_route(from.address()
 			, target.address());
 		c->hops[0] = remote->get_outgoing_route() + network_route + s->get_incoming_route();
 		c->hops[1] = s->get_outgoing_route() + network_route + remote->get_incoming_route();
 
-		c->ep[0] = s->local_endpoint(ec);
-		c->ep[1] = remote->local_endpoint(ec);
+		c->ep[0] = s->local_bound_to(ec);
+		c->ep[1] = remote->local_bound_to(ec);
 
 		aux::packet p;
 		p.type = aux::packet::type_t::syn;
@@ -267,7 +267,7 @@ namespace sim
 		if (i == m_udp_sockets.end())
 			return route();
 
-		ip::udp::endpoint src = socket.local_endpoint();
+		ip::udp::endpoint src = socket.local_bound_to();
 		route network_route = m_config.channel_route(src.address(), ep.address());
 
 		// ask the socket for its incoming route

--- a/src/socks_server.cpp
+++ b/src/socks_server.cpp
@@ -540,7 +540,7 @@ namespace sim
 		}
 
 		int const response = ec ? 1 : 0;
-		udp::endpoint ep = m_udp_associate.local_endpoint();
+		udp::endpoint ep = m_udp_associate.local_bound_to();
 		int const len = format_response(ep.address(), ep.port(), response);
 
 		if (ec)

--- a/src/tcp_socket.cpp
+++ b/src/tcp_socket.cpp
@@ -81,6 +81,7 @@ namespace ip {
 			return;
 		}
 		m_bound_to = bind_ip;
+		m_user_bound_to = bind_ip;
 		m_channel = c;
 		assert(m_forwarder);
 		c->hops[1].replace_last(m_forwarder);
@@ -104,6 +105,7 @@ namespace ip {
 		ip::tcp::endpoint addr = m_io_service.bind_socket(this, ep, ec);
 		if (ec) return ec;
 		m_bound_to = addr;
+		m_user_bound_to = ep;
 		return ec;
 	}
 
@@ -149,6 +151,7 @@ namespace ip {
 		{
 			m_io_service.unbind_socket(this, m_bound_to);
 			m_bound_to = ip::tcp::endpoint();
+			m_user_bound_to = ip::tcp::endpoint();
 		}
 		m_open = false;
 
@@ -242,26 +245,6 @@ namespace ip {
 		if (ec) throw boost::system::system_error(ec);
 	}
 
-	tcp::endpoint tcp::socket::local_endpoint(boost::system::error_code& ec)
-		const
-	{
-		if (!m_open)
-		{
-			ec = error::bad_descriptor;
-			return tcp::endpoint();
-		}
-
-		return m_bound_to;
-	}
-
-	tcp::endpoint tcp::socket::local_endpoint() const
-	{
-		boost::system::error_code ec;
-		tcp::endpoint ret = local_endpoint(ec);
-		if (ec) throw boost::system::system_error(ec);
-		return ret;
-	}
-
 	tcp::endpoint tcp::socket::remote_endpoint(boost::system::error_code& ec) const
 	{
 		if (!m_open)
@@ -314,6 +297,7 @@ namespace ip {
 				return;
 			}
 			m_bound_to = addr;
+			m_user_bound_to = addr;
 		}
 		if (m_bound_to.address().is_v4() != target.address().is_v4())
 		{

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -53,26 +53,6 @@ namespace ip {
 		close(ec);
 	}
 
-	udp::endpoint udp::socket::local_endpoint(boost::system::error_code& ec)
-		const
-	{
-		if (!m_open)
-		{
-			ec = error::bad_descriptor;
-			return udp::endpoint();
-		}
-
-		return m_bound_to;
-	}
-
-	udp::endpoint udp::socket::local_endpoint() const
-	{
-		boost::system::error_code ec;
-		udp::endpoint ret = local_endpoint(ec);
-		if (ec) throw boost::system::system_error(ec);
-		return ret;
-	}
-
 	boost::system::error_code udp::socket::bind(ip::udp::endpoint const& ep
 		, boost::system::error_code& ec)
 	{
@@ -91,6 +71,7 @@ namespace ip {
 		ip::udp::endpoint addr = m_io_service.bind_udp_socket(this, ep, ec);
 		if (ec) return ec;
 		m_bound_to = addr;
+		m_user_bound_to = ep;
 		return ec;
 	}
 
@@ -132,6 +113,7 @@ namespace ip {
 		{
 			m_io_service.unbind_udp_socket(this, m_bound_to);
 			m_bound_to = ip::udp::endpoint();
+			m_user_bound_to = ip::udp::endpoint();
 		}
 		m_open = false;
 


### PR DESCRIPTION
 regardless of concrete underlying interface. @ssiloti would you mind taking a look?

Previously, binding to "0.0.0.0" and then call ``local_address()`` would return the concrete IP it's accepting packets on. In real life the "0.0.0.0" address is preserved. This patch improves the simulation to also have this behavior