### PR TITLE
restore post() and dispatch() to forward underlying handler type to boost.asio

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -36,9 +36,6 @@ else
 		<include>/usr/sfw/include
 	;
 
-	lib boost_chrono : : <name>boost_chrono $(boost-lib-search-path)
-		: : $(boost-include-path) ;
-
 	lib boost_system : : <name>boost_system $(boost-lib-search-path)
 		: : $(boost-include-path) ;
 }
@@ -68,13 +65,20 @@ lib simulator
 
 	: # requirements
 	<include>include
-	<library>boost_chrono
 	<library>boost_system
 	<target-os>windows:<library>ws2_32
 	<target-os>windows:<library>wsock32
+	<threading>multi
 
 	<link>shared:<define>SIMULATOR_BUILDING_SHARED
 	<define>_CRT_SECURE_NO_WARNINGS
+
+	<define>BOOST_ASIO_DISABLE_BOOST_DATE_TIME
+	<define>BOOST_ASIO_HAS_MOVE
+	<define>BOOST_ASIO_ENABLE_CANCELIO
+
+	# make sure asio uses std::chrono
+	<define>BOOST_ASIO_HAS_STD_CHRONO
 
 	# disable auto-link
 	<define>BOOST_ALL_NO_LIB
@@ -82,10 +86,19 @@ lib simulator
 	: # default build
 	<warnings>all
 	<warnings-as-errors>on
+	# boost.asio has a global tss_ptr which is the head of a
+	# linked list of all invocations of run on that thread. This
+	# determines whether dispatch() will run the handler immediately
+	# not. The simulator relies on this. On windows each DLL will have
+	# its own copy of this variable, effectively causing a deadlock
+	# in the simulator. So, default to static linking
+	<link>static
 
 	: # usage requirements
 	<define>BOOST_ASIO_DISABLE_BOOST_DATE_TIME
 	<define>BOOST_ASIO_HAS_MOVE
+	<define>BOOST_ASIO_ENABLE_CANCELIO
+	<threading>multi
 	<include>include
 	<link>shared:<define>SIMULATOR_LINKING_SHARED
 	;

--- a/include/simulator/simulator.hpp
+++ b/include/simulator/simulator.hpp
@@ -1199,8 +1199,13 @@ namespace sim
 		bool stopped() const;
 		void reset();
 
-		void dispatch(aux::function<void()> handler);
-		void post(aux::function<void()> handler);
+		template <typename Handler>
+		void dispatch(Handler handler)
+		{ get_internal_service().dispatch(std::move(handler)); }
+
+		template <typename Handler>
+		void post(Handler handler)
+		{ get_internal_service().post(std::move(handler)); }
 
 		// internal interface
 		boost::asio::io_service& get_internal_service();

--- a/src/io_service.cpp
+++ b/src/io_service.cpp
@@ -63,16 +63,6 @@ namespace sim { namespace asio {
 		return m_sim.config().path_mtu(source, dest);
 	}
 
-	void io_service::dispatch(aux::function<void()> handler)
-	{
-		get_internal_service().dispatch(std::move(handler));
-	}
-
-	void io_service::post(aux::function<void()> handler)
-	{
-		get_internal_service().post(std::move(handler));
-	}
-
 	void io_service::stop()
 	{
 		// TODO: cancel all outstanding handler associated with this io_service


### PR DESCRIPTION
add comment to Jamfile about lack of dynamic linking support on windows. don't link against boost.chrono