### PR TITLE
cancel timers in their destructors, to avoid use-after-free when io_c…

### DIFF
--- a/include/simulator/queue.hpp
+++ b/include/simulator/queue.hpp
@@ -58,7 +58,7 @@ namespace sim {
 		queue& operator=(queue const&) = delete;
 
 		queue(queue&&) = default;
-		queue& operator=(queue&&) = default;
+		queue& operator=(queue&&) = delete;
 
 	private:
 

--- a/include/simulator/simulator.hpp
+++ b/include/simulator/simulator.hpp
@@ -124,6 +124,7 @@ namespace sim
 			const duration_type& expiry_time);
 		high_resolution_timer(high_resolution_timer&&) noexcept = default;
 		high_resolution_timer& operator=(high_resolution_timer&&) noexcept = default;
+		~high_resolution_timer();
 
 		std::size_t cancel(boost::system::error_code& ec);
 		std::size_t cancel();
@@ -1332,25 +1333,26 @@ namespace sim
 			, std::string hostname
 			, std::vector<asio::ip::address>& result
 			, boost::system::error_code& ec) = 0;
+
+		virtual void clear() = 0;
 	};
 
 	struct SIMULATOR_DECL default_config : configuration
 	{
 		default_config() : m_sim(nullptr) {}
 
-		virtual void build(simulation& sim) override;
-		virtual route channel_route(asio::ip::address src
-			, asio::ip::address dst) override;
-		virtual route incoming_route(asio::ip::address ip) override;
-		virtual route outgoing_route(asio::ip::address ip) override;
-		virtual int path_mtu(asio::ip::address ip1, asio::ip::address ip2)
-			override;
-		virtual chrono::high_resolution_clock::duration hostname_lookup(
+		void build(simulation& sim) override;
+		route channel_route(asio::ip::address src, asio::ip::address dst) override;
+		route incoming_route(asio::ip::address ip) override;
+		route outgoing_route(asio::ip::address ip) override;
+		int path_mtu(asio::ip::address ip1, asio::ip::address ip2) override;
+		chrono::high_resolution_clock::duration hostname_lookup(
 			asio::ip::address const& requestor
 			, std::string hostname
 			, std::vector<asio::ip::address>& result
 			, boost::system::error_code& ec) override;
 
+		void clear() override;
 	protected:
 		std::shared_ptr<queue> m_network;
 		std::map<asio::ip::address, std::shared_ptr<queue>> m_incoming;

--- a/src/default_config.cpp
+++ b/src/default_config.cpp
@@ -39,6 +39,13 @@ namespace sim {
 		m_sim = &sim;
 	}
 
+	void default_config::clear()
+	{
+		m_network.reset();
+		m_outgoing.clear();
+		m_incoming.clear();
+	}
+
 	route default_config::channel_route(
 		asio::ip::address /* src */
 		, asio::ip::address /* dst */)

--- a/src/high_resolution_timer.cpp
+++ b/src/high_resolution_timer.cpp
@@ -76,6 +76,11 @@ namespace sim
 		return 1;
 	}
 
+	high_resolution_timer::~high_resolution_timer()
+	{
+		cancel();
+	}
+
 	std::size_t high_resolution_timer::cancel()
 	{
 		if (m_expired) return 0;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -36,7 +36,12 @@ namespace sim
 		m_config.build(*this);
 	}
 
-	simulation::~simulation() {}
+	simulation::~simulation()
+	{
+		m_config.clear();
+
+		assert(m_timer_queue.empty());
+	}
 
 	std::size_t simulation::run()
 	{
@@ -44,7 +49,7 @@ namespace sim
 		return run(ec);
 	}
 
-	std::size_t simulation::run(boost::system::error_code& ec)
+	std::size_t simulation::run(boost::system::error_code& ec) try
 	{
 		std::size_t ret = 0;
 		std::size_t last_executed = 0;
@@ -83,6 +88,24 @@ namespace sim
 //			, int(last_executed), m_stopped, int(m_timer_queue.size()), int(ret));
 		return ret;
 	}
+	catch (...)
+	{
+		// cancel all outstanding timers
+		// we make a copy, since cancelling the timers will mutate m_timer_queue
+		auto queue = m_timer_queue;
+		for (auto& t : queue)
+			t->cancel();
+
+		auto listen_sockets = m_listen_sockets;
+		for (auto& s : listen_sockets)
+			s.second->cancel();
+
+		auto udp_sockets = m_udp_sockets;
+		for (auto& s : udp_sockets)
+			s.second->cancel();
+		m_stopped = true;
+		throw;
+	}
 
 	void simulation::stop() { m_stopped = true; }
 	bool simulation::stopped() const { return m_stopped; }
@@ -90,6 +113,7 @@ namespace sim
 
 	void simulation::add_timer(asio::high_resolution_timer* t)
 	{
+		assert(!m_stopped);
 		if (t->expires_at() == sim::chrono::high_resolution_clock::now())
 		{
 			std::fprintf(stderr, "WARNING: timer scheduled for current time!\n");


### PR DESCRIPTION
…ontext destructs