### PR TITLE
don't link against boost_system library

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -30,8 +30,8 @@ else
 		<include>/opt/homebrew/include
 	;
 
-	lib boost_system : : <name>boost_system $(boost-lib-search-path)
-		: : $(boost-include-path) ;
+	# boost_system is a header-only library now, but we still need to find the boost headers
+	alias boost_system : : : : $(boost-include-path) ;
 }
 
 SOURCES =


### PR DESCRIPTION
it's header-only now